### PR TITLE
#39476: Without file system locations, hide 'Jump to ...' button.

### DIFF
--- a/python/tk_multi_about/dialog.py
+++ b/python/tk_multi_about/dialog.py
@@ -48,12 +48,17 @@ class AppDialog(QtGui.QWidget):
         self.ui.support.clicked.connect( self.open_helpdesk )
         self.ui.reload_apps.clicked.connect( self.reload )
         self.ui.close.clicked.connect( self.close )
-                
+
         # load data from shotgun
         self.setup_context_list()
         self.setup_apps_list()
         self.setup_environment_list()
-        
+
+        # When there is no file system locations, hide the "Jump to the File System" button.
+        if not self._app.context.filesystem_locations:
+            self.ui.jump_to_fs.setVisible(False)
+
+
     ########################################################################################
     # make sure we trap when the dialog is closed so that we can shut down 
     # our threads. Nuke does not do proper cleanup on exit.


### PR DESCRIPTION
When there is no file system locations, hide the "Jump to the File System" button.