### PR TITLE
#45715 Show Shotgun site url in the work area info

### DIFF
--- a/python/tk_multi_about/context_browser.py
+++ b/python/tk_multi_about/context_browser.py
@@ -86,7 +86,7 @@ class ContextBrowserWidget(browser_widget.BrowserWidget):
             # add the site url
             link_color = self._app.engine.style_constants["SG_HIGHLIGHT_COLOR"]
             full_site_url = result.get("shotgun_url") if result.get("shotgun_url") else ""
-            nice_name_site_url = self._clean_url(full_site_url)
+            nice_name_site_url = self._get_url_nice_name(full_site_url)
             site_display_template = "<a href=\"{url}\" style=\"color:{color}\" >{display_url}</a>"
             site_str = site_display_template.format(url=full_site_url, display_url=nice_name_site_url, color=link_color)
             details.append(site_str)
@@ -169,7 +169,7 @@ class ContextBrowserWidget(browser_widget.BrowserWidget):
         widget.ui.details.setOpenExternalLinks(True)
         return widget
 
-    def _clean_url(self, url):
+    def _get_url_nice_name(self, url):
         """
         Removes the "https://", "http://" from the beginning for the url
         :param url: str that is an url.

--- a/python/tk_multi_about/context_browser.py
+++ b/python/tk_multi_about/context_browser.py
@@ -85,8 +85,11 @@ class ContextBrowserWidget(browser_widget.BrowserWidget):
             details = []
             details.append("<b>Project %s</b>" % d.get("name"))
             details.append( d.get("sg_description") if d.get("sg_description") else "No Description" )
+
+            link_color = self._app.engine.style_constants.get("SG_HIGHLIGHT_COLOR","#18A7E3")
             site_url = result.get("shotgun_url") if result.get("shotgun_url") else ""
-            site_str= "Site: <a href=\"{url}\" style=\"color:#95b0cb\" >{url}</a> ".format(url=site_url)
+            site_str= "Site: <a href=\"{url}\" style=\"color:{color}\" >{url}</a> ".format(url=site_url,
+                                                                                           color=link_color)
             details.append(site_str)
             i.set_details("<br>".join(details))
             i.sg_data = d

--- a/python/tk_multi_about/context_browser.py
+++ b/python/tk_multi_about/context_browser.py
@@ -8,16 +8,16 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import tank
+import sgtk
 import os
 import sys
 import datetime
 import threading 
 
 
-from tank.platform.qt import QtCore, QtGui
+from sgtk.platform.qt import QtCore, QtGui
 
-browser_widget = tank.platform.import_framework("tk-framework-widget", "browser_widget")
+browser_widget = sgtk.platform.import_framework("tk-framework-widget", "browser_widget")
 
 
 class ContextBrowserWidget(browser_widget.BrowserWidget):
@@ -98,7 +98,7 @@ class ContextBrowserWidget(browser_widget.BrowserWidget):
             
             i = self.add_item(browser_widget.ListItem)
             details = []
-            nice_name = tank.util.get_entity_type_display_name(self._app.tank, d.get("type"))
+            nice_name = sgtk.util.get_entity_type_display_name(self._app.sgtk, d.get("type"))
             details.append("<b>%s %s</b>" % (nice_name, d.get("code")))
             details.append( d.get("description") if d.get("description") else "No Description" )         
             i.set_details("<br>".join(details))
@@ -112,7 +112,7 @@ class ContextBrowserWidget(browser_widget.BrowserWidget):
             
             i = self.add_item(browser_widget.ListItem)
             details = []
-            nice_name = tank.util.get_entity_type_display_name(self._app.tank, d.get("type"))
+            nice_name = sgtk.util.get_entity_type_display_name(self._app.sgtk, d.get("type"))
             details.append("<b>%s %s</b>" % (nice_name, d.get("code")))
             details.append( d.get("description") if d.get("description") else "No Description" )    
             i.set_details("<br>".join(details))

--- a/python/tk_multi_about/context_browser.py
+++ b/python/tk_multi_about/context_browser.py
@@ -57,6 +57,12 @@ class ContextBrowserWidget(browser_widget.BrowserWidget):
                                                       [ ["id", "is", ctx.task["id"]] ], 
                                                       ["content", "image", "task_assignees", "sg_status_list"])
 
+        if self._app.sgtk.shotgun_url:
+            # we gather the shotgun url for just the site, rather than from the context as this could
+            # look odd if the url points to a task but is displayed under the project heading
+            # when the context contains more than just the project.
+            data["shotgun_url"] = self._app.sgtk.shotgun_url
+
 
         data["additional"] = []            
         for ae in ctx.additional_entities:
@@ -78,7 +84,8 @@ class ContextBrowserWidget(browser_widget.BrowserWidget):
             i = self.add_item(browser_widget.ListItem)
             details = []
             details.append("<b>Project %s</b>" % d.get("name"))
-            details.append( d.get("sg_description") if d.get("sg_description") else "No Description" )            
+            details.append( d.get("sg_description") if d.get("sg_description") else "No Description" )
+            details.append("Site: %s" % result.get("shotgun_url") if result.get("shotgun_url") else "")
             i.set_details("<br>".join(details))
             i.sg_data = d
             i.setToolTip("Double click to see more details in Shotgun.")

--- a/python/tk_multi_about/context_browser.py
+++ b/python/tk_multi_about/context_browser.py
@@ -85,7 +85,9 @@ class ContextBrowserWidget(browser_widget.BrowserWidget):
             details = []
             details.append("<b>Project %s</b>" % d.get("name"))
             details.append( d.get("sg_description") if d.get("sg_description") else "No Description" )
-            details.append("Site: %s" % result.get("shotgun_url") if result.get("shotgun_url") else "")
+            site_url = result.get("shotgun_url") if result.get("shotgun_url") else ""
+            site_str= "Site: <a href=\"{url}\" style=\"color:#95b0cb\" >{url}</a> ".format(url=site_url)
+            details.append(site_str)
             i.set_details("<br>".join(details))
             i.sg_data = d
             i.setToolTip("Double click to see more details in Shotgun.")


### PR DESCRIPTION
Now shows the Shotgun Site URL on the project context item in the work area info.
This is to make it a bit easier for users who use multiple sites and want to check which site they are currently connecting to.

<img width="338" alt="shotgun__your_current_work_area" src="https://user-images.githubusercontent.com/3777228/33211883-80701a18-d118-11e7-8ab4-2be8bb3f5cd5.png">
