### PR TITLE
Removing tk_core_ref in azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,6 @@ jobs:
   parameters:
     has_ui_tests: true
     has_unit_tests: false
-    tk_core_ref: sg-22646-shotgrid
     additional_repositories:
       # These are required by tk-toolchain's tk-run-app
       - name: tk-framework-qtwidgets


### PR DESCRIPTION
Removing tk_core_ref since it was a temporary solution to have CI tests pass