### PR TITLE
SG-43664 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 26.1.0
+    rev: 26.5.1
     hooks:
     - id: black
       language_version: python3

--- a/info.yml
+++ b/info.yml
@@ -28,6 +28,7 @@ description: "Shows a breakdown of your current environment and configuration."
 requires_shotgun_version:
 requires_core_version: "v0.19.1"
 requires_engine_version:
+minimum_python_version: "3.9"
 
 # the frameworks required to run this app
 frameworks:

--- a/python/tk_multi_about/context_browser.py
+++ b/python/tk_multi_about/context_browser.py
@@ -185,7 +185,7 @@ class ContextBrowserWidget(browser_widget.BrowserWidget):
         Adds a list item. Returns the created object.
         We override the base class so we can make the urls clickable
         """
-        widget = super(ContextBrowserWidget, self).add_item(item_class)
+        widget = super().add_item(item_class)
         widget.ui.details.setOpenExternalLinks(True)
         return widget
 


### PR DESCRIPTION
## Summary
- Set `minimum_python_version: "3.9"` in `info.yml`
- Modernised `super()` call in `context_browser.py`

## Test plan
- [ ] Pre-commit passes (black, check-ast, check-yaml, whitespace)
- [ ] App loads and About dialog displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)